### PR TITLE
Add xhr passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 # data-mocks
 
-
 <img src="https://i.imgur.com/gEG3io2.jpg" height="250">
 
 Library to mock local data requests using Fetch and XHR
@@ -28,6 +27,8 @@ Assuming your project is using `fetch` / `XHR` for HTTP operations:
 - Hooray, all HTTP requests to mocked endpoints will now respond with the mocked data you have specified
 
 # Examples
+
+## Basic mock injection without scenarios (XHR and Fetch)
 
 ```javascript
 import { injectMocks } from 'data-mocks';
@@ -76,6 +77,8 @@ In the above example we are using `axios` as our XHR library of choice. However
 `data-mocks` will work with any library that uses `XMLHttpRequest` under the hood.
 
 ---
+
+## Mock injection with scenarios
 
 ```javascript
 import { injectMocks, extractScenarioFromLocation } from 'data-mocks';
@@ -148,14 +151,21 @@ In this example, if we load our site up with `scenario=failedLogin` in the query
 | responseCode | number | ❌       | Response code. Defaults to 200                                     |
 | delay        | number | ❌       | Delay (in milliseconds) before response is returned. Defaults to 0 |
 
+### MockConfig
+
+| Property            | Type    | Required | Description                                                                                   |
+| ------------------- | ------- | -------- | --------------------------------------------------------------------------------------------- |
+| allowXHRPassthrough | boolean | ❌       | Any unmatched routes for XHR will pass through to the actual endpoint, rather than be mocked. |
+
 ## Exported functions
 
 ### injectMocks
 
-| Parameter | Type                            | Required | Description                                |
-| --------- | ------------------------------- | -------- | ------------------------------------------ |
-| scenarios | [Scenarios](#Scenarios)[]       | ✅       | A mapping of scenarios and their responses |
-| scenario  | keyof [Scenarios](#Scenarios)[] | ❌       | The scenario to run. Defaults to `default` |
+| Parameter | Type                            | Required | Description                                                                 |
+| --------- | ------------------------------- | -------- | --------------------------------------------------------------------------- |
+| scenarios | [Scenarios](#Scenarios)[]       | ✅       | A mapping of scenarios and their responses                                  |
+| scenario  | keyof [Scenarios](#Scenarios)[] | ❌       | The scenario to run. Defaults to `default`                                  |
+| config    | MockConfig                      | ❌       | Config object that allows for different behaviour of how mocks are injected |
 
 ### extractScenarioFromLocation
 

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -181,22 +181,23 @@ describe('data-mocks', () => {
   });
 
   describe('Mock config', () => {
+    const scenarios: Scenarios = {
+      default: [
+        {
+          url: /foo/,
+          method: 'GET',
+          response: { foo: 'GET' },
+          responseCode: 200
+        }
+      ]
+    };
+
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
     test('Sets XHR proxy if allowPassthrough is set in config', () => {
       const xhrSpy = jest.spyOn(XHRMock, 'use');
-      const scenarios: Scenarios = {
-        default: [
-          {
-            url: /foo/,
-            method: 'GET',
-            response: { foo: 'GET' },
-            responseCode: 200
-          }
-        ]
-      };
 
       const mockConfig: MockConfig = {
         allowXHRPassthrough: true
@@ -209,16 +210,6 @@ describe('data-mocks', () => {
 
     test('Does not set XHR proxy if allowPassthrough is false', () => {
       const xhrSpy = jest.spyOn(XHRMock, 'use');
-      const scenarios: Scenarios = {
-        default: [
-          {
-            url: /foo/,
-            method: 'GET',
-            response: { foo: 'GET' },
-            responseCode: 200
-          }
-        ]
-      };
 
       const mockConfig: MockConfig = {
         allowXHRPassthrough: false
@@ -231,16 +222,6 @@ describe('data-mocks', () => {
 
     test('Does not set XHR proxy if config is not passed', () => {
       const xhrSpy = jest.spyOn(XHRMock, 'use');
-      const scenarios: Scenarios = {
-        default: [
-          {
-            url: /foo/,
-            method: 'GET',
-            response: { foo: 'GET' },
-            responseCode: 200
-          }
-        ]
-      };
 
       injectMocks(scenarios, 'default');
       expect(xhrSpy).toHaveBeenCalledTimes(1);

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -3,10 +3,11 @@ import {
   injectMocks,
   HttpMethod,
   Scenarios,
+  MockConfig,
   extractScenarioFromLocation,
   reduceAllMocksForScenario
 } from './mocks';
-import XHRMock from 'xhr-mock';
+import XHRMock, { proxy } from 'xhr-mock';
 import * as FetchMock from 'fetch-mock';
 
 declare var jsdom: any;
@@ -176,6 +177,74 @@ describe('data-mocks', () => {
       expect(() => extractScenarioFromLocation(window.location)).toThrowError(
         'Only one scenario may be used at a time'
       );
+    });
+  });
+
+  describe('Mock config', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('Sets XHR proxy if allowPassthrough is set in config', () => {
+      const xhrSpy = jest.spyOn(XHRMock, 'use');
+      const scenarios: Scenarios = {
+        default: [
+          {
+            url: /foo/,
+            method: 'GET',
+            response: { foo: 'GET' },
+            responseCode: 200
+          }
+        ]
+      };
+
+      const mockConfig: MockConfig = {
+        allowXHRPassthrough: true
+      };
+
+      injectMocks(scenarios, 'default', mockConfig);
+      expect(xhrSpy).toHaveBeenCalledTimes(2);
+      expect(xhrSpy).toHaveBeenCalledWith(proxy);
+    });
+
+    test('Does not set XHR proxy if allowPassthrough is false', () => {
+      const xhrSpy = jest.spyOn(XHRMock, 'use');
+      const scenarios: Scenarios = {
+        default: [
+          {
+            url: /foo/,
+            method: 'GET',
+            response: { foo: 'GET' },
+            responseCode: 200
+          }
+        ]
+      };
+
+      const mockConfig: MockConfig = {
+        allowXHRPassthrough: false
+      };
+
+      injectMocks(scenarios, 'default', mockConfig);
+      expect(xhrSpy).toHaveBeenCalledTimes(1);
+      expect(xhrSpy).not.toHaveBeenCalledWith(proxy);
+    });
+
+    test('Does not set XHR proxy if config is not passed', () => {
+      const xhrSpy = jest.spyOn(XHRMock, 'use');
+      const scenarios: Scenarios = {
+        default: [
+          {
+            url: /foo/,
+            method: 'GET',
+            response: { foo: 'GET' },
+            responseCode: 200
+          }
+        ]
+      };
+
+      injectMocks(scenarios, 'default');
+      expect(xhrSpy).toHaveBeenCalledTimes(1);
+      expect(xhrSpy).not.toHaveBeenCalledWith(proxy);
     });
   });
 });

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,8 +1,12 @@
 import * as FetchMock from 'fetch-mock';
-import XHRMock, { delay as xhrMockDelay } from 'xhr-mock';
+import XHRMock, { delay as xhrMockDelay, proxy } from 'xhr-mock';
 import { parse } from 'query-string';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export interface MockConfig {
+  allowXHRPassthrough: boolean;
+}
 
 export interface Mock {
   url: RegExp;
@@ -33,9 +37,14 @@ export const extractScenarioFromLocation = (location: Location): string => {
  */
 export const injectMocks = (
   scenarios: Scenarios,
-  scenario: keyof Scenarios = 'default'
+  scenario: keyof Scenarios = 'default',
+  config?: MockConfig
 ): void => {
   XHRMock.setup();
+
+  if (config && config.allowXHRPassthrough) {
+    XHRMock.use(proxy);
+  }
 
   const mocks: Mock[] =
     scenario !== 'default'


### PR DESCRIPTION
XHR mock allows us to passthrough requests that haven't been mocked and hit the real server.
In order to do that, I've added an optional config object which will have a "allowXHRPassthrough" flag that will set the proxy.