### PR TITLE
Add response header mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ const scenarios = {
       response: { another: 'response' },
       responseCode: 200,
       delay: 1000
+    },
+    {
+      url: /endpoint-with-headers/,
+      method: 'GET',
+      response: { same: 'response' },
+      responseHeaders: { token: 'mock-token' },
+      responseCode: 200
     }
   ]
 };
@@ -143,13 +150,14 @@ In this example, if we load our site up with `scenario=failedLogin` in the query
 
 ### Mock
 
-| Property     | Type   | Required | Description                                                        |
-| ------------ | ------ | -------- | ------------------------------------------------------------------ |
-| url          | RegExp | ✅       | Regular expression that matches part of the URL                    |
-| method       | string | ✅       | HTTP method matching one of 'GET', 'POST', 'PUT', 'DELETE'         |
-| response     | any    | ✅       | Body of the response                                               |
-| responseCode | number | ❌       | Response code. Defaults to 200                                     |
-| delay        | number | ❌       | Delay (in milliseconds) before response is returned. Defaults to 0 |
+| Property        | Type   | Required | Description                                                        |
+| --------------- | ------ | -------- | ------------------------------------------------------------------ |
+| url             | RegExp | ✅       | Regular expression that matches part of the URL                    |
+| method          | string | ✅       | HTTP method matching one of 'GET', 'POST', 'PUT', 'DELETE'         |
+| response        | any    | ✅       | Body of the response                                               |
+| responseCode    | number | ❌       | Response code. Defaults to 200                                     |
+| responseHeaders | object | ❌       | Response headers. Defaults to empty                                |
+| delay           | number | ❌       | Delay (in milliseconds) before response is returned. Defaults to 0 |
 
 ### MockConfig
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-mocks",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -19,8 +19,18 @@ describe('data-mocks', () => {
     httpMethods.forEach(httpMethod => {
       const scenarios: Scenarios = {
         default: [
-          { url: /foo/, method: httpMethod, response: {}, responseCode: 200 },
-          { url: /bar/, method: httpMethod, response: {}, responseCode: 200 }
+          {
+            url: /foo/,
+            method: httpMethod,
+            response: {},
+            responseCode: 200
+          },
+          {
+            url: /bar/,
+            method: httpMethod,
+            response: {},
+            responseCode: 200
+          }
         ]
       };
       test(`Mocks calls for ${httpMethod}`, () => {
@@ -43,8 +53,20 @@ describe('data-mocks', () => {
   describe('Scenarios', () => {
     const scenarios: Scenarios = {
       default: [
-        { url: /foo/, method: 'GET', response: {}, responseCode: 200 },
-        { url: /bar/, method: 'GET', response: {}, responseCode: 200 },
+        {
+          url: /foo/,
+          method: 'GET',
+          response: {},
+          responseCode: 200,
+          responseHeaders: { token: 'foo' }
+        },
+        {
+          url: /bar/,
+          method: 'GET',
+          response: {},
+          responseCode: 200,
+          responseHeaders: { token: 'bar' }
+        },
         { url: /bar/, method: 'POST', response: {}, responseCode: 200 }
       ],
       someScenario: [
@@ -69,8 +91,20 @@ describe('data-mocks', () => {
       const result = reduceAllMocksForScenario(scenarios, 'default');
 
       expect(result).toEqual([
-        { url: /foo/, method: 'GET', response: {}, responseCode: 200 },
-        { url: /bar/, method: 'GET', response: {}, responseCode: 200 },
+        {
+          url: /foo/,
+          method: 'GET',
+          response: {},
+          responseCode: 200,
+          responseHeaders: { token: 'foo' }
+        },
+        {
+          url: /bar/,
+          method: 'GET',
+          response: {},
+          responseCode: 200,
+          responseHeaders: { token: 'bar' }
+        },
         { url: /bar/, method: 'POST', response: {}, responseCode: 200 }
       ]);
     });
@@ -79,8 +113,19 @@ describe('data-mocks', () => {
       const result = reduceAllMocksForScenario(scenarios, 'someScenario');
 
       expect(result).toEqual([
-        { url: /foo/, method: 'GET', response: {}, responseCode: 200 },
-        { url: /bar/, method: 'POST', response: {}, responseCode: 200 },
+        {
+          url: /foo/,
+          method: 'GET',
+          response: {},
+          responseCode: 200,
+          responseHeaders: { token: 'foo' }
+        },
+        {
+          url: /bar/,
+          method: 'POST',
+          response: {},
+          responseCode: 200
+        },
         {
           url: /bar/,
           method: 'GET',
@@ -112,14 +157,15 @@ describe('data-mocks', () => {
     });
   });
 
-  describe(`XHR mock calls`, () => {
+  describe('XHR mock calls', () => {
     const scenarios: Scenarios = {
       default: [
         {
           url: /foo/,
           method: 'GET',
           response: { foo: 'GET' },
-          responseCode: 200
+          responseCode: 200,
+          responseHeaders: { token: 'foo' }
         },
         {
           url: /foo/,
@@ -149,19 +195,23 @@ describe('data-mocks', () => {
     test(`Correct response for mocked XHR endpoints`, async () => {
       const resGET = await axios.get('/foo');
       expect(resGET.data).toEqual({ foo: 'GET' });
+      expect(resGET.headers).toEqual({ token: 'foo' });
 
       const resPOST = await axios.post('/foo');
       expect(resPOST.data).toEqual({ foo: 'POST' });
+      expect(resPOST.headers).toEqual({});
 
       const resPUT = await axios.put('/foo');
       expect(resPUT.data).toEqual({ foo: 'PUT' });
+      expect(resPUT.headers).toEqual({});
 
       const resDELETE = await axios.delete('/foo');
       expect(resDELETE.data).toEqual({ foo: 'DELETE' });
+      expect(resDELETE.headers).toEqual({});
     });
   });
 
-  describe(`Extract scenario from location`, () => {
+  describe('Extract scenario from location', () => {
     test(`Correct scenario name is returned`, () => {
       window.history.pushState({}, 'Test', '/?scenario=test');
       expect(extractScenarioFromLocation(window.location)).toBe('test');

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -171,13 +171,15 @@ describe('data-mocks', () => {
           url: /foo/,
           method: 'POST',
           response: { foo: 'POST' },
-          responseCode: 200
+          responseCode: 200,
+          responseHeaders: {}
         },
         {
           url: /foo/,
           method: 'PUT',
           response: { foo: 'PUT' },
-          responseCode: 200
+          responseCode: 200,
+          responseHeaders: undefined
         },
         {
           url: /foo/,

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -13,6 +13,7 @@ export interface Mock {
   method: HttpMethod;
   response: object;
   responseCode?: number;
+  responseHeaders?: Record<string, string>;
   delay?: number;
 }
 
@@ -55,43 +56,57 @@ export const injectMocks = (
     throw new Error('Unable to instantiate mocks');
   }
 
-  mocks.forEach(({ method, url, response, responseCode = 200, delay = 0 }) => {
-    const finalResponse = {
-      body: response,
-      status: responseCode
-    };
+  mocks.forEach(
+    ({
+      method,
+      url,
+      response,
+      responseCode = 200,
+      responseHeaders,
+      delay = 0
+    }) => {
+      const finalResponse = {
+        body: response,
+        status: responseCode,
+        headers: responseHeaders
+      };
 
-    switch (method) {
-      case 'GET':
-        FetchMock.get(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
-        });
-        XHRMock.get(url, xhrMockDelay(finalResponse, delay));
-        break;
-      case 'POST':
-        FetchMock.post(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
-        });
-        XHRMock.post(url, xhrMockDelay(finalResponse, delay));
-        break;
-      case 'PUT':
-        FetchMock.put(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
-        });
-        XHRMock.put(url, xhrMockDelay(finalResponse, delay));
-        break;
-      case 'DELETE':
-        FetchMock.delete(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
-        });
-        XHRMock.delete(url, xhrMockDelay(finalResponse, delay));
-        break;
-      default:
-        throw new Error(
-          `Unrecognised HTTP method ${method} - please check your mock configuration`
-        );
+      switch (method) {
+        case 'GET':
+          FetchMock.get(url, () => addDelay(delay).then(() => finalResponse), {
+            overwriteRoutes: true
+          });
+          XHRMock.get(url, xhrMockDelay(finalResponse, delay));
+          break;
+        case 'POST':
+          FetchMock.post(url, () => addDelay(delay).then(() => finalResponse), {
+            overwriteRoutes: true
+          });
+          XHRMock.post(url, xhrMockDelay(finalResponse, delay));
+          break;
+        case 'PUT':
+          FetchMock.put(url, () => addDelay(delay).then(() => finalResponse), {
+            overwriteRoutes: true
+          });
+          XHRMock.put(url, xhrMockDelay(finalResponse, delay));
+          break;
+        case 'DELETE':
+          FetchMock.delete(
+            url,
+            () => addDelay(delay).then(() => finalResponse),
+            {
+              overwriteRoutes: true
+            }
+          );
+          XHRMock.delete(url, xhrMockDelay(finalResponse, delay));
+          break;
+        default:
+          throw new Error(
+            `Unrecognised HTTP method ${method} - please check your mock configuration`
+          );
+      }
     }
-  });
+  );
 };
 
 /**


### PR DESCRIPTION
`xhr-mock` and `fetch-mock` both support mocking response headers in a similar way. This PR enables that functionality in `data-mocks`.

- Updated implementation
- Updated tests
- Updated documentation

Although I've updated existing tests, it only covers XHR. Not sure how to test this further.