### PR TITLE
Invert route matching logic so multiple methods for the same route ar…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-mocks",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -64,25 +64,25 @@ export const injectMocks = (
     switch (method) {
       case 'GET':
         FetchMock.get(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
+          overwriteRoutes: false
         });
         XHRMock.get(url, xhrMockDelay(finalResponse, delay));
         break;
       case 'POST':
         FetchMock.post(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
+          overwriteRoutes: false
         });
         XHRMock.post(url, xhrMockDelay(finalResponse, delay));
         break;
       case 'PUT':
         FetchMock.put(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
+          overwriteRoutes: false
         });
         XHRMock.put(url, xhrMockDelay(finalResponse, delay));
         break;
       case 'DELETE':
         FetchMock.delete(url, () => addDelay(delay).then(() => finalResponse), {
-          overwriteRoutes: true
+          overwriteRoutes: false
         });
         XHRMock.delete(url, xhrMockDelay(finalResponse, delay));
         break;


### PR DESCRIPTION
…e supported

For some silly reason, I had things so that any additional mocks to the same endpoint would override previous mocks for that endpoint, meaning that you couldn't have a mock for a GET + POST for an endpoint (only the most recent mock would work).

This fixes it.

See http://www.wheresrhys.co.uk/fetch-mock/ and ctrl+f for `overwriteRoutes` for more info on how this works.