### PR TITLE
downgrade query string to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-mocks",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -778,9 +778,9 @@
       "dev": true
     },
     "@types/query-string": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-6.1.1.tgz",
-      "integrity": "sha512-wRUeF7KN2yxCMw4VoXzPh3GWStbGaiyVjyX22fG7mpSzt6etLvsA2S0g0IuGeXGwVNIlztzVmGP6AxZMmYTQhw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-5.1.0.tgz",
+      "integrity": "sha512-9/sJK+T04pNq7uwReR0CLxqXj1dhxiTapZ1tIxA0trEsT6FRS0bz09YMcMb7tsVBTm4RJ0NEBYGsAjoEmqoFXg==",
       "dev": true
     },
     "abab": {
@@ -5209,8 +5209,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5776,12 +5775,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
-      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "strict-uri-encode": "^2.0.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -6515,9 +6515,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "fetch-mock": "^7.0.7",
     "node-fetch": "^2.2.0",
-    "query-string": "^6.1.0",
+    "query-string": "^5.1.1",
     "xhr-mock": "^2.4.1"
   },
   "devDependencies": {
@@ -44,7 +44,7 @@
     "@babel/preset-env": "^7.2.0",
     "@types/fetch-mock": "^6.0.4",
     "@types/jest": "^23.3.10",
-    "@types/query-string": "^6.1.0",
+    "@types/query-string": "^5.1.0",
     "axios": "^0.18.0",
     "husky": "^1.1.1",
     "jest": "^23.6.0",


### PR DESCRIPTION
# Downgrade `query-string` to `v5`:

## Why?
Query string V6 exposes es6 syntax in the exported module. This does not get transpilled by the loader and means that a user who wants to test with mocks in older browsers such as ie11 can not do so.

They say on the the npm page for [query-string:](https://www.npmjs.com/package/query-string)

> This module targets Node.js 6 or later and the latest version of Chrome, Firefox, and Safari. If you want support for older browsers, or, if your project is using create-react-app, use version 5: npm install query-string@5.

I made the change locally and all unit tests are passing.