### PR TITLE
Uses unbundled version of fetch-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-mocks-temp",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "main": "dist/mocks.js",
   "types": "dist/mocks.d.ts",
   "repository": "git@github.com:ovotech/data-mocks.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-mocks-temp",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "main": "dist/mocks.js",
   "types": "dist/mocks.d.ts",
   "repository": "git@github.com:ovotech/data-mocks.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "data-mocks",
-  "version": "2.5.6",
+  "name": "data-mocks-temp",
+  "version": "2.5.7",
   "main": "dist/mocks.js",
   "types": "dist/mocks.d.ts",
   "repository": "git@github.com:ovotech/data-mocks.git",

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -8,7 +8,7 @@ import {
   reduceAllMocksForScenario
 } from './mocks';
 import XHRMock, { proxy } from 'xhr-mock';
-import * as FetchMock from 'fetch-mock';
+import * as FetchMock from 'fetch-mock/src/client';
 
 describe('data-mocks', () => {
   describe('HTTP methods', () => {

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,4 +1,4 @@
-import * as FetchMock from 'fetch-mock';
+import * as FetchMock from 'fetch-mock/src/client';
 import XHRMock, { delay as xhrMockDelay, proxy } from 'xhr-mock';
 import { parse } from 'query-string';
 


### PR DESCRIPTION
Currently fetch-mock ships a transpiled copy of its code but it is broken because of some babel wizardry. This makes data-mocks use the unbundled version of fetch-mock. This fixes https://github.com/ovotech/data-mocks/issues/36.