### PR TITLE
Add documentation for the allowFetchPassthrough config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ In this example, if we load our site up with `scenario=failedLogin` in the query
 
 ### MockConfig
 
-| Property            | Type    | Required | Description                                                                                   |
-| ------------------- | ------- | -------- | --------------------------------------------------------------------------------------------- |
-| allowXHRPassthrough | boolean | ❌       | Any unmatched routes for XHR will pass through to the actual endpoint, rather than be mocked. |
+| Property              | Type    | Required | Description                                                                                                        |
+| -------------------   | ------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| allowXHRPassthrough   | boolean | ❌       | Any unmatched routes for XHR will pass through to the actual endpoint, rather than be mocked. Defaults to false.   |
+| allowFetchPassthrough | boolean | ❌       | Any unmatched routes for fetch will pass through to the actual endpoint, rather than be mocked. Defaults to false. |
 
 ## Exported functions
 

--- a/src/mocks.test.ts
+++ b/src/mocks.test.ts
@@ -294,7 +294,7 @@ describe('data-mocks', () => {
       expect(FetchMock.config.fallbackToNetwork).toBe(false);
     });
 
-    test('Sets fallbackToNetwork to false if allowFetchPassthrough is set to true in config', () => {
+    test('Sets fallbackToNetwork to true if allowFetchPassthrough is set to true in config', () => {
       const mockConfig: MockConfig = {
         allowFetchPassthrough: true
       };


### PR DESCRIPTION
Seems like `allowFetchPassthrough` was missing from the README, so this PR adds it.

I also fixed a test description for `allowFetchPassthrough`. The test was checking the right thing (that setting `allowFetchPassthrough` to `true` would set `fallbackToNetwork` to `true` as well), but the description said the opposite.