### PR TITLE
allow string response

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -12,7 +12,7 @@ export interface MockConfig {
 export interface Mock {
   url: RegExp;
   method: HttpMethod;
-  response: object;
+  response: object | string;
   responseCode?: number;
   responseHeaders?: Record<string, string>;
   delay?: number;


### PR DESCRIPTION
Currently the response type only expects `object`. this PR adds `string` as an acceptable response type.