### PR TITLE
Add ability to disable console warnings for fetch fallback

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -35,6 +35,10 @@ export const injectMocks = (
     FetchMock.config.fallbackToNetwork = true;
   }
 
+  if (config && config.disableConsoleWarningsForFetch) {
+    FetchMock.config.warnOnFallback = false;
+  }
+
   const mocks: Mock[] =
     scenario !== 'default'
       ? reduceAllMocksForScenario(scenarios, scenario)

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 export type MockConfig = {
   allowXHRPassthrough?: boolean;
   allowFetchPassthrough?: boolean;
+  disableConsoleWarningsForFetch?: boolean;
 };
 
 export type HttpMock = {


### PR DESCRIPTION
Closes #54 

This PR adds a config option (`disableConsoleWarningsForFetch`) that, when enabled, will suppress any console warnings generated by fetch-mock fallbacks 